### PR TITLE
memoise s3_client

### DIFF
--- a/lib/blobby/s3_store.rb
+++ b/lib/blobby/s3_store.rb
@@ -97,7 +97,7 @@ module Blobby
     private
 
     def s3_client
-      ::Aws::S3::Client.new(s3_options)
+      @s3_client ||= ::Aws::S3::Client.new(s3_options)
     end
 
     def s3_endpoint_for_bucket


### PR DESCRIPTION
Every time a new s3 client is initialised it makes a call to the metadata service. AWS rate limit this service and this can result in errors for high volumes of transactions.