### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/blobby/s3_store.rb
+++ b/lib/blobby/s3_store.rb
@@ -93,8 +93,8 @@ module Blobby
 
       def force_binary(s)
         return s unless s.respond_to?(:encoding)
-        return s if s.encoding.name == "ASCII-8BIT"
-        s.dup.force_encoding("ASCII-8BIT")
+        return s if s.encoding == Encoding::BINARY
+        s.b
       end
 
     end


### PR DESCRIPTION
Comparing the names is much less efficient than comparing the instance directly.
    
It may also change in the future: https://bugs.ruby-lang.org/issues/18576